### PR TITLE
Configure via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Database settings
+DB_HOST=localhost
+DB_PORT=3306
+DB_NAME=dirigeai
+DB_USERNAME=root
+DB_PASSWORD=
+
+# Mercado Pago
+MERCADOPAGO_ACCESS_TOKEN=YOUR_ACCESS_TOKEN_HERE

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ DirigeAí é um sistema de locação de veículos focado em locatários e locado
     ```
 
 3. Crie seu banco de dados MySQL e importe as tabelas necessárias.
-4. Configure a conexão com o banco de dados em `config/db.php`.
-5. Realize a configuração do Mercado Pago em `config/mercadopago.php`.
+4. Copie o arquivo `.env.example` para `.env` e preencha com suas credenciais de banco de dados e token do Mercado Pago.
+5. A aplicação lerá essas variáveis automaticamente ao iniciar.
 
 ## Instalação do Mercado Pago
 

--- a/config/db.php
+++ b/config/db.php
@@ -1,10 +1,11 @@
 <?php
+// Database connection using environment variables for easy production setup
 try {
-    $host = 'localhost';
-    $port = 8001; // Verifique se está correta a porta configurada
-    $dbname = 'dirigeai'; // Substitua pelo nome do seu banco
-    $username = 'root'; // Substitua pelo usuário do banco
-    $password = ''; // Substitua pela senha do banco
+    $host = getenv('DB_HOST') ?: 'localhost';
+    $port = getenv('DB_PORT') ?: 3306;
+    $dbname = getenv('DB_NAME') ?: 'dirigeai';
+    $username = getenv('DB_USERNAME') ?: 'root';
+    $password = getenv('DB_PASSWORD') ?: '';
 
     // Criar a conexão PDO
     $pdo = new PDO("mysql:host=$host;port=$port;dbname=$dbname", $username, $password);

--- a/config/mercadopago.php
+++ b/config/mercadopago.php
@@ -1,7 +1,10 @@
 <?php
 // Caminho para o autoload dentro da pasta config
-require_once __DIR__ . '/autoload.php';  // Ou o caminho correto, caso tenha movido para uma subpasta
+require_once __DIR__ . '/autoload.php';  // Ajuste o caminho se necessário
 
-// Agora o SDK do Mercado Pago estará disponível
-MercadoPago\SDK::setAccessToken('TEST-3911994694042579-020201-bb9af4d14ed4b7a3f91b6fb3e54114ce-2246647458');
+// Configure the Mercado Pago SDK using an access token from the environment
+$token = getenv('MERCADOPAGO_ACCESS_TOKEN');
+if ($token) {
+    MercadoPago\SDK::setAccessToken($token);
+}
 ?>

--- a/config/notificacao.php
+++ b/config/notificacao.php
@@ -8,7 +8,7 @@ if (isset($evento['type']) && $evento['type'] == "payment") {
     $payment_id = $evento['data']['id'];
 
     // Consultar o status do pagamento na API do Mercado Pago
-    $access_token = "APP_USR-3911994694042579-020201-9c00076201ed71d02162dc7a91f487dc-2246647458";
+    $access_token = getenv('MERCADOPAGO_ACCESS_TOKEN');
     $url = "https://api.mercadopago.com/v1/payments/$payment_id";
 
     $ch = curl_init($url);

--- a/config/test.php
+++ b/config/test.php
@@ -2,6 +2,9 @@
 // Verifica se o autoload existe
 require_once __DIR__ . '/../vendor/autoload.php';  // Caminho correto para o autoload gerado pelo Composer
 
-// Agora o SDK do Mercado Pago estará disponível
-MercadoPago\SDK::setAccessToken('TEST-3911994694042579-020201-bb9af4d14ed4b7a3f91b6fb3e54114ce-2246647458');
+// Usa o token de acesso definido no ambiente
+$token = getenv('MERCADOPAGO_ACCESS_TOKEN');
+if ($token) {
+    MercadoPago\SDK::setAccessToken($token);
+}
 ?>

--- a/php/cadastrar_locador.php
+++ b/php/cadastrar_locador.php
@@ -5,7 +5,10 @@ require_once '../config/db.php'; // Conexão com o banco de dados
 
 // Configuração do Mercado Pago
 $config = new MercadoPagoConfig();
-$config->setAccessToken('TEST-3911994694042579-020201-bb9af4d14ed4b7a3f91b6fb3e54114ce-2246647458');
+$token = getenv('MERCADOPAGO_ACCESS_TOKEN');
+if ($token) {
+    $config->setAccessToken($token);
+}
 
 // Verifica se o formulário foi enviado via POST
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/php/mercadopago_registrar_locador.php
+++ b/php/mercadopago_registrar_locador.php
@@ -1,11 +1,6 @@
 <?php
-// Conexão com o banco de dados
-try {
-    $pdo = new PDO("mysql:host=localhost;port=8001;dbname=dirigeai", "root", "");
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-} catch (PDOException $e) {
-    die("Erro na conexão com o banco de dados: " . $e->getMessage());
-}
+// Conexão com o banco de dados usando configuração compartilhada
+require_once '../config/db.php';
 
 // Capturar os dados do formulário
 $nome = $_POST['nome'] ?? null;


### PR DESCRIPTION
## Summary
- add `.env.example` for environment variables
- update database and Mercado Pago config files to read from env vars
- adjust sample scripts to share configuration
- document env configuration in README

## Testing
- `composer validate` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854981b7f5883258058b53332afa694