### PR TITLE
Add sample SQL for test users

### DIFF
--- a/scripts/create_test_users.sql
+++ b/scripts/create_test_users.sql
@@ -1,0 +1,5 @@
+-- SQL script to create three test users: admin, locador, and locatario
+INSERT INTO usuarios (nome, email, senha, telefone, tipo_usuario) VALUES
+  ('Admin Teste', 'admin@teste.com', '$2b$12$ERS0ShjZ9IO07UYx0QAaOOL6mqBZeyT/6moPVMDE1eQzvhrChIKsi', '0000000000', 'admin'),
+  ('Locador Teste', 'locador@teste.com', '$2b$12$yzXgtkzytCfJmh86uzbpjugXbyI9rKDPcx0Xwn/It6YMUT0N3IACu', '1111111111', 'locador'),
+  ('Locatario Teste', 'locatario@teste.com', '$2b$12$vphNY6KNFLWn/MOWoIBJT.2GjZ5pBUQs3vnMvDJX8e6ACjm6nnp66', '2222222222', 'locatario');


### PR DESCRIPTION
## Summary
- add a SQL script to create sample admin, locador and locatario accounts

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a3aadad483258e917cc308b652cc